### PR TITLE
:construction: Missing Args

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,4 +13,9 @@ read contract
 echo Enter constructor arguments separated by spaces \(eg 1 2 3\):
 read -ra args
 
-forge create ./src/${contract}.sol:${contract} -i --rpc-url $rpc --constructor-args ${args}
+if [ -z "$args" ]
+then
+  forge create ./src/${contract}.sol:${contract} -i --rpc-url $rpc
+else
+  forge create ./src/${contract}.sol:${contract} -i --rpc-url $rpc --constructor-args ${args}
+fi

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -21,4 +21,9 @@ read contract
 echo Enter constructor arguments separated by spaces \(eg 1 2 3\):
 read -ra args
 
-forge create ./src/${contract}.sol:${contract} -i --rpc-url "http://localhost:8545" --constructor-args ${args}
+if [ -z "$args" ]
+then
+  forge create ./src/${contract}.sol:${contract} -i --rpc-url "http://localhost:8545"
+else
+  forge create ./src/${contract}.sol:${contract} -i --rpc-url "http://localhost:8545" --constructor-args ${args}
+fi

--- a/scripts/deploy_rinkeby.sh
+++ b/scripts/deploy_rinkeby.sh
@@ -13,4 +13,9 @@ read contract
 echo Enter constructor arguments separated by spaces \(eg 1 2 3\):
 read -ra args
 
-forge create ./src/${contract}.sol:${contract} -i --rpc-url $rpc --constructor-args ${args}
+if [ -z "$args" ]
+then
+  forge create ./src/${contract}.sol:${contract} -i --rpc-url $rpc
+else
+  forge create ./src/${contract}.sol:${contract} -i --rpc-url $rpc --constructor-args ${args}
+fi

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -29,4 +29,9 @@ echo Enter your Etherscan API Key:
 
 read -s etherscan
 
-forge verify-contract --compiler-version \"$version\" $deployed ./src/${contract}.sol:${contract} $etherscan --constructor-args ${args}
+if [ -z "$args" ]
+then
+  forge verify-contract --compiler-version \"$version\" $deployed ./src/${contract}.sol:${contract} $etherscan
+else
+  forge verify-contract --compiler-version \"$version\" $deployed ./src/${contract}.sol:${contract} $etherscan --constructor-args ${args}
+fi

--- a/scripts/verify_rinkeby.sh
+++ b/scripts/verify_rinkeby.sh
@@ -29,4 +29,10 @@ echo Enter your Etherscan API Key:
 
 read -s etherscan
 
-forge verify-contract --compiler-version \"$version\" $deployed ./src/${contract}.sol:${contract} $etherscan --constructor-args ${args}
+if [ -z "$args" ]
+then
+  forge verify-contract --compiler-version \"$version\" $deployed ./src/${contract}.sol:${contract} $etherscan
+else
+  forge verify-contract --compiler-version \"$version\" $deployed ./src/${contract}.sol:${contract} $etherscan --constructor-args ${args}
+fi
+


### PR DESCRIPTION
## Overview

This PR adds checks for scripts if args are empty.
This is necessary because `forge` requires an input to the `--constructor-args` flag.