### PR TITLE
Fix network name in comments

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Read the Rinkeby RPC URL
+# Read the Mainnet RPC URL
 echo Enter Your Mainnet RPC URL:
 echo Example: "https://eth-mainnet.alchemyapi.io/v2/XXXXXXXXXX"
 read -s rpc


### PR DESCRIPTION
The mainnet deploy script says "rinkeby" in a comment.