### PR TITLE
Fix verify.sh

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -31,7 +31,7 @@ read -s etherscan
 
 if [ -z "$args" ]
 then
-  forge verify-contract --compiler-version \"$version\" $deployed ./src/${contract}.sol:${contract} $etherscan
+  forge verify-contract --compiler-version "$version" $deployed ./src/${contract}.sol:${contract} $etherscan
 else
-  forge verify-contract --compiler-version \"$version\" $deployed ./src/${contract}.sol:${contract} $etherscan --constructor-args ${args}
+  forge verify-contract --compiler-version "$version" $deployed ./src/${contract}.sol:${contract} $etherscan --constructor-args ${args}
 fi

--- a/scripts/verify_rinkeby.sh
+++ b/scripts/verify_rinkeby.sh
@@ -31,8 +31,8 @@ read -s etherscan
 
 if [ -z "$args" ]
 then
-  forge verify-contract --compiler-version \"$version\" $deployed ./src/${contract}.sol:${contract} $etherscan --chain-id 4
+  forge verify-contract --compiler-version "$version" $deployed ./src/${contract}.sol:${contract} $etherscan --chain-id 4
 else
-  forge verify-contract --compiler-version \"$version\" $deployed ./src/${contract}.sol:${contract} $etherscan --constructor-args ${args} --chain-id 4
+  forge verify-contract --compiler-version "$version" $deployed ./src/${contract}.sol:${contract} $etherscan --constructor-args ${args} --chain-id 4
 fi
 


### PR DESCRIPTION
I have tested this only on the latest macOS so I'm not sure if it breaks on linux / windows but after removing the quotes, I was able to verify a contract.

Before:
```
Error:
   0: Encountered an error verifying this contract:
      Response: `NOTOK`
      Details: `Invalid compiler version. See https://etherscan.io/solcversions for list of supported solc versions`

Location:
   cli/src/cmd/forge/verify.rs:127
```

After:

```
Submitted contract for verification:
                Response: `OK`
                GUID: `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
                url: https://etherscan.io//address/0x000…000#code
```

I believe this fixes #12